### PR TITLE
Conecta Pagos con Neon

### DIFF
--- a/src/app/api/payables/route.ts
+++ b/src/app/api/payables/route.ts
@@ -1,0 +1,265 @@
+import { NextResponse } from "next/server";
+import { query } from "@/lib/db";
+
+const ORGANIZATION_ID = "7356d336-7207-415d-87e2-d05fd6e70efe";
+
+function toNumber(value: unknown): number {
+  if (value == null) return 0;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function toInt(value: unknown): number {
+  if (value == null) return 0;
+  const n = Number(value);
+  return Number.isFinite(n) ? Math.trunc(n) : 0;
+}
+
+function toIsoDate(value: unknown): string | null {
+  if (value == null) return null;
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (typeof value === "string") return value.slice(0, 10);
+  return null;
+}
+
+export async function GET() {
+  try {
+    const [
+      orgRes,
+      kpiBillsRes,
+      kpiDueWeekRes,
+      kpiScheduledRes,
+      calendarRes,
+      upcomingRes,
+      vendorsRes,
+      recentRes,
+    ] = await Promise.all([
+      query(
+        `SELECT id, name, default_currency
+         FROM organizations
+         WHERE id = $1::uuid`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT COALESCE(SUM(amount), 0) AS total
+         FROM bills
+         WHERE organization_id = $1::uuid AND status = 'pending'`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT COALESCE(SUM(amount), 0) AS total
+         FROM bills
+         WHERE organization_id = $1::uuid
+           AND status = 'pending'
+           AND due_date IS NOT NULL
+           AND due_date >= CURRENT_DATE
+           AND due_date <= CURRENT_DATE + INTERVAL '7 days'`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT
+           COALESCE(SUM(amount), 0) AS total_amount,
+           COUNT(*)::int AS total_count
+         FROM payments
+         WHERE organization_id = $1::uuid AND status = 'scheduled'`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `WITH bounds AS (
+           SELECT
+             (CURRENT_DATE - INTERVAL '30 days')::date AS start_dt,
+             (CURRENT_DATE + INTERVAL '30 days')::date AS end_dt
+         ),
+         days AS (
+           SELECT generate_series(
+             (SELECT start_dt FROM bounds),
+             (SELECT end_dt FROM bounds),
+             INTERVAL '1 day'
+           )::date AS cal_date
+         ),
+         sched AS (
+           SELECT due_date::date AS dt, SUM(amount) AS amt
+           FROM bills
+           WHERE organization_id = $1::uuid
+             AND status = 'pending'
+             AND due_date IS NOT NULL
+             AND due_date >= CURRENT_DATE
+           GROUP BY due_date::date
+         ),
+         overdue AS (
+           SELECT due_date::date AS dt, SUM(amount) AS amt
+           FROM bills
+           WHERE organization_id = $1::uuid
+             AND status = 'pending'
+             AND due_date IS NOT NULL
+             AND due_date < CURRENT_DATE
+           GROUP BY due_date::date
+         ),
+         paid AS (
+           SELECT payment_date::date AS dt, SUM(amount) AS amt
+           FROM payments
+           WHERE organization_id = $1::uuid
+             AND status = 'paid'
+             AND payment_date IS NOT NULL
+           GROUP BY payment_date::date
+         )
+         SELECT
+           d.cal_date AS date,
+           COALESCE(sched.amt, 0) AS scheduled_amount,
+           COALESCE(paid.amt, 0) AS paid_amount,
+           COALESCE(overdue.amt, 0) AS overdue_amount
+         FROM days d
+         LEFT JOIN sched ON sched.dt = d.cal_date
+         LEFT JOIN paid ON paid.dt = d.cal_date
+         LEFT JOIN overdue ON overdue.dt = d.cal_date
+         ORDER BY d.cal_date ASC`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT
+           b.id,
+           b.due_date AS date,
+           COALESCE(NULLIF(TRIM(v.name), ''), 'Sin proveedor') AS vendor_name,
+           COALESCE(TRIM(b.notes), 'Bill pendiente') AS description,
+           b.amount,
+           b.status
+         FROM bills b
+         LEFT JOIN vendors v ON v.id = b.vendor_id AND v.organization_id = b.organization_id
+         WHERE b.organization_id = $1::uuid AND b.status = 'pending'
+         ORDER BY b.due_date ASC NULLS LAST, b.id ASC
+         LIMIT 10`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT
+           b.vendor_id,
+           COALESCE(NULLIF(TRIM(v.name), ''), 'Sin proveedor') AS vendor_name,
+           COUNT(b.id)::int AS pending_bills_count,
+           COALESCE(SUM(b.amount), 0) AS open_amount
+         FROM bills b
+         LEFT JOIN vendors v ON v.id = b.vendor_id AND v.organization_id = b.organization_id
+         WHERE b.organization_id = $1::uuid AND b.status = 'pending'
+         GROUP BY b.vendor_id, COALESCE(NULLIF(TRIM(v.name), ''), 'Sin proveedor')
+         ORDER BY open_amount DESC NULLS LAST, pending_bills_count DESC
+         LIMIT 10`,
+        [ORGANIZATION_ID]
+      ),
+      query(
+        `SELECT
+           p.id,
+           p.payment_date AS date,
+           COALESCE(NULLIF(TRIM(v.name), ''), 'Sin proveedor') AS vendor_name,
+           COALESCE(NULLIF(TRIM(p.method), ''), '—') AS method,
+           p.amount,
+           p.status
+         FROM payments p
+         LEFT JOIN vendors v ON v.id = p.vendor_id AND v.organization_id = p.organization_id
+         WHERE p.organization_id = $1::uuid AND p.status = 'paid'
+         ORDER BY p.payment_date DESC NULLS LAST, p.id DESC
+         LIMIT 10`,
+        [ORGANIZATION_ID]
+      ),
+    ]);
+
+    const orgRow = orgRes.rows[0] as
+      | { id: string; name: string; default_currency: string | null }
+      | undefined;
+
+    const organization = orgRow
+      ? {
+          id: orgRow.id,
+          name: orgRow.name,
+          default_currency: orgRow.default_currency,
+        }
+      : null;
+
+    const totalPayable = toNumber(kpiBillsRes.rows[0]?.total);
+    const dueThisWeek = toNumber(kpiDueWeekRes.rows[0]?.total);
+    const schedRow = kpiScheduledRes.rows[0] as
+      | { total_amount?: unknown; total_count?: unknown }
+      | undefined;
+    const pendingApprovalAmount = toNumber(schedRow?.total_amount);
+    const pendingApprovalCount = toInt(schedRow?.total_count);
+
+    const calendar = (calendarRes.rows as {
+      date: Date | string;
+      scheduled_amount: unknown;
+      paid_amount: unknown;
+      overdue_amount: unknown;
+    }[]).map((row) => ({
+      date: toIsoDate(row.date),
+      scheduledAmount: toNumber(row.scheduled_amount),
+      paidAmount: toNumber(row.paid_amount),
+      overdueAmount: toNumber(row.overdue_amount),
+    }));
+
+    const upcomingPayments = (upcomingRes.rows as {
+      id: string;
+      date: Date | string | null;
+      vendor_name: string;
+      description: string;
+      amount: unknown;
+      status: string;
+    }[]).map((row) => ({
+      id: row.id,
+      date: toIsoDate(row.date),
+      vendorName: row.vendor_name,
+      description: row.description,
+      amount: toNumber(row.amount),
+      status: row.status,
+    }));
+
+    const vendors = (vendorsRes.rows as {
+      vendor_id: string | null;
+      vendor_name: string;
+      pending_bills_count: number;
+      open_amount: unknown;
+    }[]).map((row) => ({
+      vendorId: row.vendor_id,
+      vendorName: row.vendor_name,
+      pendingBillsCount: toInt(row.pending_bills_count),
+      openAmount: toNumber(row.open_amount),
+    }));
+
+    const recentPayments = (recentRes.rows as {
+      id: string;
+      date: Date | string | null;
+      vendor_name: string;
+      method: string;
+      amount: unknown;
+      status: string;
+    }[]).map((row) => ({
+      id: row.id,
+      date: toIsoDate(row.date),
+      vendorName: row.vendor_name,
+      method: row.method,
+      amount: toNumber(row.amount),
+      status: row.status,
+    }));
+
+    return NextResponse.json({
+      ok: true,
+      organization,
+      kpis: {
+        totalPayable,
+        dueThisWeek,
+        pendingApprovalAmount,
+        pendingApprovalCount,
+      },
+      calendar,
+      upcomingPayments,
+      vendors,
+      recentPayments,
+    });
+  } catch (error) {
+    console.error("Error fetching payables:", error);
+
+    return NextResponse.json(
+      {
+        ok: false,
+        error: "Error fetching payables",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/pagos/page.tsx
+++ b/src/app/pagos/page.tsx
@@ -6,7 +6,6 @@ import { Topbar } from "@/components/inicio/Topbar";
 import { mockCompanies } from "@/components/inicio/mock";
 import { IconX } from "@/components/inicio/icons";
 import { useSidebarNavigate } from "@/components/shell/useSidebarNavigate";
-import { mockPagosByCompanyId } from "@/components/pagos/mock";
 import { PagosKpiRow } from "@/components/pagos/KpiRow";
 import { PaymentsCalendarChart } from "@/components/pagos/PaymentsCalendarChart";
 import { UpcomingPaymentsTable } from "@/components/pagos/UpcomingPaymentsTable";
@@ -14,22 +13,80 @@ import { VendorsTable } from "@/components/pagos/VendorsTable";
 import { RecentPaymentsTable } from "@/components/pagos/RecentPaymentsTable";
 import { useRequireDemoAuth } from "@/components/shell/useRequireDemoAuth";
 import { ProgramarPagoModal } from "@/components/shared/ProgramarPagoModal";
+import {
+  mapPayablesApiPayload,
+  type PayablesApiSuccessPayload,
+} from "@/components/pagos/mapPayablesApi";
 
 export default function PagosPage() {
   useRequireDemoAuth();
 
-  const activeCompanyId = mockCompanies[0]?.id ?? "acme-ar";
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
   const [pagoModalOpen, setPagoModalOpen] = React.useState(false);
 
-  const company =
-    mockCompanies.find((c) => c.id === activeCompanyId) ?? mockCompanies[0];
-  const data =
-    mockPagosByCompanyId[company.id] ?? mockPagosByCompanyId["acme-ar"];
+  const [payablesLoading, setPayablesLoading] = React.useState(true);
+  const [payablesError, setPayablesError] = React.useState<string | null>(null);
+  const [payablesView, setPayablesView] = React.useState<
+    ReturnType<typeof mapPayablesApiPayload> | null
+  >(null);
 
   const onNavigate = useSidebarNavigate({
     onAfterNavigate: () => setSidebarOpen(false),
   });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setPayablesLoading(true);
+    setPayablesError(null);
+
+    fetch("/api/payables", { cache: "no-store" })
+      .then(async (res) => {
+        const body = (await res.json()) as PayablesApiSuccessPayload & {
+          ok?: boolean;
+          error?: string;
+        };
+        if (!res.ok || body.ok !== true) {
+          throw new Error(
+            typeof body.error === "string"
+              ? body.error
+              : "No se pudieron cargar los datos de pagos.",
+          );
+        }
+        if (cancelled) return;
+        setPayablesView(mapPayablesApiPayload(body as PayablesApiSuccessPayload));
+        setPayablesError(null);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setPayablesView(null);
+        setPayablesError(e instanceof Error ? e.message : "Error al cargar pagos.");
+      })
+      .finally(() => {
+        if (!cancelled) setPayablesLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const topbarCompanies = React.useMemo(() => {
+    if (payablesView?.organization) {
+      return [
+        {
+          id: payablesView.organization.id,
+          name: payablesView.organization.name,
+          currency: payablesView.currency,
+        },
+      ];
+    }
+    return mockCompanies;
+  }, [payablesView]);
+
+  const activeCompanyId =
+    payablesView?.organization?.id ?? mockCompanies[0]?.id ?? "acme-ar";
+
+  const displayCurrency = payablesView?.currency ?? mockCompanies[0]?.currency ?? "ARS";
 
   return (
     <div className="qp-shell">
@@ -67,7 +124,7 @@ export default function PagosPage() {
 
         <div className="min-w-0 flex-1">
           <Topbar
-            companies={mockCompanies}
+            companies={topbarCompanies}
             activeCompanyId={activeCompanyId}
             onCompanyChange={() => {}}
             onOpenSidebar={() => setSidebarOpen(true)}
@@ -84,12 +141,20 @@ export default function PagosPage() {
                     <p className="mt-1 text-sm text-muted-foreground">
                       Pagos a proveedores, vencimientos y aprobaciones.
                     </p>
+                    <p className="mt-1.5 text-xs text-muted-foreground">
+                      {payablesLoading
+                        ? "Cargando datos…"
+                        : payablesError
+                          ? "No se pudo actualizar"
+                          : "Datos desde servidor"}
+                    </p>
                   </div>
                   <div className="flex items-center gap-2">
                     <button
                       type="button"
                       className="inline-flex h-10 cursor-pointer items-center justify-center rounded-full bg-[color:var(--quipu-accent)] px-4 text-sm font-medium text-white transition hover:opacity-95 active:translate-y-px disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50"
                       onClick={() => setPagoModalOpen(true)}
+                      disabled={payablesLoading}
                     >
                       Programar pago
                     </button>
@@ -97,39 +162,54 @@ export default function PagosPage() {
                 </div>
               </header>
 
-              <section className="space-y-4">
-                <PagosKpiRow kpis={data.kpis} currency={company.currency} />
-
-                <PaymentsCalendarChart
-                  title="Calendario de pagos"
-                  points={data.calendar.points}
-                  currency={company.currency}
-                />
-
-                <div className="grid gap-4 lg:grid-cols-3">
-                  <div className="lg:col-span-1">
-                    <UpcomingPaymentsTable
-                      title="Próximos pagos"
-                      items={data.upcoming}
-                      currency={company.currency}
-                    />
-                  </div>
-                  <div className="lg:col-span-1">
-                    <VendorsTable
-                      title="Proveedores"
-                      items={data.vendors}
-                      currency={company.currency}
-                    />
-                  </div>
-                  <div className="lg:col-span-1">
-                    <RecentPaymentsTable
-                      title="Pagos recientes"
-                      items={data.recent}
-                      currency={company.currency}
-                    />
-                  </div>
+              {payablesError ? (
+                <div
+                  className="mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-900"
+                  role="alert"
+                >
+                  {payablesError}
                 </div>
-              </section>
+              ) : null}
+
+              {payablesLoading ? (
+                <div className="rounded-2xl border border-border bg-card px-4 py-10 text-center text-sm text-muted-foreground">
+                  Cargando datos de pagos…
+                </div>
+              ) : payablesView ? (
+                <section className="space-y-4">
+                  <PagosKpiRow kpis={payablesView.kpis} currency={displayCurrency} />
+
+                  <PaymentsCalendarChart
+                    title="Calendario de pagos"
+                    points={payablesView.calendar.points}
+                    currency={displayCurrency}
+                  />
+
+                  <div className="grid gap-4 lg:grid-cols-3">
+                    <div className="lg:col-span-1">
+                      <UpcomingPaymentsTable
+                        title="Próximos pagos"
+                        items={payablesView.upcoming}
+                        currency={displayCurrency}
+                      />
+                    </div>
+                    <div className="lg:col-span-1">
+                      <VendorsTable
+                        title="Proveedores"
+                        items={payablesView.vendors}
+                        currency={displayCurrency}
+                      />
+                    </div>
+                    <div className="lg:col-span-1">
+                      <RecentPaymentsTable
+                        title="Pagos recientes"
+                        items={payablesView.recent}
+                        currency={displayCurrency}
+                      />
+                    </div>
+                  </div>
+                </section>
+              ) : null}
             </div>
           </main>
         </div>
@@ -139,4 +219,3 @@ export default function PagosPage() {
     </div>
   );
 }
-

--- a/src/components/pagos/mapPayablesApi.ts
+++ b/src/components/pagos/mapPayablesApi.ts
@@ -1,0 +1,158 @@
+import type { CurrencyCode } from "@/components/inicio/mock";
+import type {
+  PagosKpi,
+  PaymentsCalendarPoint,
+  RecentPayment,
+  UpcomingPayment,
+  VendorRow,
+} from "./mock";
+
+export type PayablesApiSuccessPayload = {
+  ok: true;
+  organization: {
+    id: string;
+    name: string;
+    default_currency: string | null;
+  } | null;
+  kpis: {
+    totalPayable: number;
+    dueThisWeek: number;
+    pendingApprovalAmount: number;
+    pendingApprovalCount: number;
+  };
+  calendar: Array<{
+    date: string | null;
+    scheduledAmount: number;
+    paidAmount: number;
+    overdueAmount: number;
+  }>;
+  upcomingPayments: Array<{
+    id: string;
+    date: string | null;
+    vendorName: string;
+    description: string;
+    amount: number;
+    status: string;
+  }>;
+  vendors: Array<{
+    vendorId: string | null;
+    vendorName: string;
+    pendingBillsCount: number;
+    openAmount: number;
+  }>;
+  recentPayments: Array<{
+    id: string;
+    date: string | null;
+    vendorName: string;
+    method: string;
+    amount: number;
+    status: string;
+  }>;
+};
+
+function mapDefaultCurrency(value: string | null | undefined): CurrencyCode {
+  const u = (value ?? "").trim().toUpperCase();
+  if (u === "USD") return "USD";
+  return "ARS";
+}
+
+function safeIsoDate(value: string | null | undefined): string {
+  if (value && /^\d{4}-\d{2}-\d{2}/.test(value)) return value.slice(0, 10);
+  const t = new Date();
+  t.setHours(12, 0, 0, 0);
+  return t.toISOString().slice(0, 10);
+}
+
+function calendarPointLabel(iso: string): string {
+  if (!/^\d{4}-\d{2}-\d{2}/.test(iso)) return "—";
+  const d = new Date(`${iso.slice(0, 10)}T12:00:00`);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d
+    .toLocaleDateString("es-AR", { day: "numeric", month: "short" })
+    .replace(/\./g, "")
+    .trim();
+}
+
+function approvalHint(count: number): string {
+  if (count <= 0) return "Sin pagos en aprobación";
+  if (count === 1) return "1 pago pendiente de aprobación";
+  return `${count} pagos pendientes de aprobación`;
+}
+
+function mapPaymentStatus(apiStatus: string): RecentPayment["status"] {
+  const s = (apiStatus ?? "").toLowerCase();
+  if (s === "paid" || s === "pagado") return "Pagado";
+  if (s === "scheduled" || s === "programado") return "Programado";
+  if (s === "overdue" || s === "vencido") return "Vencido";
+  return "Pagado";
+}
+
+export function mapPayablesApiPayload(payload: PayablesApiSuccessPayload) {
+  const currency = mapDefaultCurrency(payload.organization?.default_currency);
+
+  const kpis: PagosKpi[] = [
+    {
+      key: "totalPorPagar",
+      label: "Total por pagar",
+      value: payload.kpis.totalPayable,
+      format: "money",
+    },
+    {
+      key: "venceSemana",
+      label: "Por vencer esta semana",
+      value: payload.kpis.dueThisWeek,
+      format: "money",
+    },
+    {
+      key: "aprobacionesPendientes",
+      label: "Aprobaciones pendientes",
+      value: payload.kpis.pendingApprovalAmount,
+      format: "money",
+      hint: approvalHint(payload.kpis.pendingApprovalCount),
+    },
+  ];
+
+  const calendarPoints: PaymentsCalendarPoint[] = payload.calendar.map((row, idx) => {
+    const iso = row.date && /^\d{4}-\d{2}-\d{2}/.test(row.date) ? row.date.slice(0, 10) : "";
+    return {
+      label: iso ? calendarPointLabel(iso) : `Día ${idx + 1}`,
+      scheduled: row.scheduledAmount,
+      paid: row.paidAmount,
+      overdue: row.overdueAmount,
+    };
+  });
+
+  const upcoming: UpcomingPayment[] = payload.upcomingPayments.map((u) => ({
+    id: u.id,
+    date: safeIsoDate(u.date),
+    vendor: u.vendorName || "—",
+    description: u.description || "—",
+    amount: u.amount,
+  }));
+
+  const vendors: VendorRow[] = payload.vendors.map((v, idx) => ({
+    id: v.vendorId ?? `sin-proveedor-${idx}`,
+    vendor: v.vendorName || "—",
+    pendingCount: v.pendingBillsCount,
+    amount: v.openAmount,
+  }));
+
+  const recent: RecentPayment[] = payload.recentPayments.map((p) => ({
+    id: p.id,
+    date: safeIsoDate(p.date),
+    vendor: p.vendorName || "—",
+    method: p.method || "—",
+    amount: p.amount,
+    status: mapPaymentStatus(p.status),
+  }));
+
+  return {
+    currency,
+    organization: payload.organization,
+    kpis,
+    calendar: { points: calendarPoints },
+    upcoming,
+    vendors,
+    recent,
+  };
+}


### PR DESCRIPTION
Conecta el módulo Pagos con datos reales desde Neon.

Cambios:
- Crea API /api/payables
- Conecta pantalla Pagos con datos reales
- Agrega mapper para adaptar la respuesta de la API a los componentes existentes
- Mantiene diseño visual actual

Refs #21
Refs #24