### PR TITLE
Mejora visual de saldos bancarios

### DIFF
--- a/src/components/tesoreria/BankBalancesTable.tsx
+++ b/src/components/tesoreria/BankBalancesTable.tsx
@@ -12,7 +12,7 @@ export type TreasuryBankBalancesTableProps = {
   currency: CurrencyCode;
 };
 
-const PAGE_SIZE = 3;
+const PAGE_SIZE = 5;
 
 function StatusPill({ status }: { status: BankBalanceRow["status"] }) {
   const tone =

--- a/src/components/tesoreria/mapTreasuryApi.ts
+++ b/src/components/tesoreria/mapTreasuryApi.ts
@@ -54,13 +54,33 @@ function mapBankStatus(apiStatus: string): BankBalanceRow["status"] {
   return apiStatus.toLowerCase() === "active" ? "Activa" : "Inactiva";
 }
 
+function accountTypeLabel(accountType: string | null | undefined): string {
+  const key = (accountType ?? "").trim().toLowerCase();
+  switch (key) {
+    case "bank":
+    case "banks":
+      return "Banco";
+    case "wallet":
+      return "Billetera";
+    case "cash":
+      return "Efectivo";
+    case "investment":
+    case "investments":
+      return "Inversión";
+    case "in_transit":
+      return "En tránsito";
+    default:
+      return key.length > 0 ? "Otro" : "";
+  }
+}
+
 function formatAccountCell(accountName: string, accountType: string): string {
   const name = (accountName ?? "").trim();
-  const type = (accountType ?? "").trim();
+  const typeLabel = accountTypeLabel(accountType);
   if (name && name !== "—") {
-    return type && type !== name ? `${name} · ${type}` : name;
+    return typeLabel && typeLabel !== name ? `${name} · ${typeLabel}` : name;
   }
-  if (type) return type;
+  if (typeLabel) return typeLabel;
   return "—";
 }
 


### PR DESCRIPTION
Mejora la visualización de saldos bancarios en Tesorería.

Cambios:
- Reemplaza labels técnicos como bank por Banco
- Muestra más cuentas bancarias visibles
- Mantiene diseño visual actual y datos desde Neon

Refs #19
Refs #21